### PR TITLE
Fix to make remote xhr work against a mobile service

### DIFF
--- a/todo-backbonejs/BackboneTodo/config.xml
+++ b/todo-backbonejs/BackboneTodo/config.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <widget xmlns:cdv="http://cordova.apache.org/ns/1.0" xmlns:vs="http://schemas.microsoft.com/appx/2014/htmlapps" id="io.cordova.myapp123ad8" version="1.0.0" xmlns="http://www.w3.org/ns/widgets" defaultlocale="en-US">
   <name>BackboneToDo</name>
   <description>A blank project that uses Apache Cordova to help you build an app that targets multiple mobile platforms: Android, iOS, Windows, and Windows Phone.</description>
@@ -91,4 +91,5 @@
   </platform>
   <vs:plugin name="com.microsoft.azure-mobile-services" version="1.2.8" />
   <vs:plugin name="org.apache.cordova.geolocation" version="0.3.12" />
+  <vs:plugin name="cordova-plugin-whitelist" version="1.0.0" />
 </widget>

--- a/todo-backbonejs/BackboneTodo/www/index.html
+++ b/todo-backbonejs/BackboneTodo/www/index.html
@@ -5,6 +5,7 @@ Copyright (c) Microsoft. All rights reserved.  Licensed under the MIT license. S
 <html>
 <head>
     <meta charset="utf-8" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; connect-src 'self' https:; frame-src 'self' https:; script-src 'self' 'unsafe-eval'">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=0" />
     <title>Backbone Todo Sample</title>
 </head>


### PR DESCRIPTION
It looks like you now need the Whitelist plugin to be able to make remote xhr requests to Mobile Services (or any remote URL). I added a Content-Security-Policy header policy value that works, but you may want to investigate whether or not you want to make it more restrictive.
