### PR TITLE
Initial commit of the offline build automation example

### DIFF
--- a/build-offline/BuildOffline.proj
+++ b/build-offline/BuildOffline.proj
@@ -1,0 +1,24 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{2E9E3B90-A96B-48F0-B58F-CB861EFEF5FE}</ProjectGuid>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
+    <OutputPath Condition="'$(OutputPath)'==''">bin\Debug</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|AnyCPU'">
+    <OutputPath Condition="'$(OutputPath)'==''">bin\Release</OutputPath>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Include="ExtractOfflineArchive.cmd" />
+    <None Include="CreateOfflineArchive.cmd" />
+    <None Include="UnzipDependencies.ps1" />
+    <None Include="ZipDependencies.ps1" />
+  </ItemGroup>
+  <Target Name="Default">
+    <Exec Command="$(MSBuildThisFileDirectory)CreateOfflineArchive.cmd $(OutputPath)\BuildOffline" />
+    <Copy SourceFiles="ExtractOfflineArchive.cmd;UnzipDependencies.ps1" DestinationFolder="$(OutputPath)\BuildOffline" />
+  </Target>
+</Project>

--- a/build-offline/CreateOfflineArchive.cmd
+++ b/build-offline/CreateOfflineArchive.cmd
@@ -1,0 +1,119 @@
+@ECHO off
+
+ECHO.
+ECHO Tools for Apache Cordova Offline Build Archive Creator
+ECHO ------------------------------------------------------
+ECHO.
+
+SET OutputDirectory=%1
+SET SkipDownloadNodeNpm=%2
+SET SevenZip=%3
+
+IF [%OutputDirectory%]==[] goto INPUTERROR
+IF [%SevenZip%]==[] SET SevenZip=%HomeDrive%\Program Files\7-Zip\7z.exe
+
+SET BuildOfflineTempDir=%TEMP%\BuildOffline
+SET DependenciesDir=%BuildOfflineTempDir%\Dependencies
+SET NpmCacheSourceDir=%APPDATA%\npm-cache
+SET NpmModulesSourceDir=%APPDATA%\npm\node_modules
+IF /I "%robocopy%"=="" Set robocopy=robocopy /NJH /NJS
+SET NugetPackageDir=..\..\NugetPackages\VS.ExternalAPIs.ApacheCordovaTools.external.dev15.1.0.16060601\BuildOffline
+
+SET CordovaWindowsVersion=4.3.2
+SET CordovaVersion=6.1.1
+SET SandboxedNpmVersion=2.15.1
+SET CordovaPluginWhitelistVersion=1
+
+ECHO Cleaning up previous package...
+:: ====================================================
+IF exist "%BuildOfflineTempDir%" rmdir /s /q "%BuildOfflineTempDir%"
+
+ECHO Clearing npm-cache...
+:: ====================================================
+IF exist "%NpmCacheSourceDir%" rmdir /s /q "%NpmCacheSourceDir%"
+
+REM !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+REM ADD PACKAGES YOU WANT TO INSTALL TO THIS LIST
+REM !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+ECHO Globally installing packages to establish npm-cache...
+:: ====================================================
+call npm install -g npm@%SandboxedNpmVersion%
+call npm install -g ..\Packages\vs-tac15
+call npm install -g cordova@%CordovaVersion%
+call npm install -g cordova-windows@%CordovaWindowsVersion%
+call npm install -g cordova-plugin-whitelist@%CordovaPluginWhitelistVersion%
+call npm uninstall -g npm
+
+ECHO Establishing temporary directory to create zip file...
+:: ====================================================
+mkdir %BuildOfflineTempDir%
+mkdir %DependenciesDir%
+mkdir %DependenciesDir%\npm-cache
+mkdir %DependenciesDir%\lib\windows\cordova
+
+ECHO Copying npm node_modules...
+:: ====================================================
+%robocopy% /E "%NpmModulesSourceDir%" "%DependenciesDir%\node_modules"
+
+ECHO Copying npm-cache...
+:: ====================================================
+%robocopy% /E "%NpmCacheSourceDir%" "%DependenciesDir%\npm-cache"
+
+ECHO Extracting Windows platform package...
+:: ====================================================
+"%SevenZip%" x "%DependenciesDir%\npm-cache\cordova-windows\%CordovaWindowsVersion%\package.tgz" -o"%OfflineBuildTempDir%\Package" -aoa
+"%SevenZip%" x "%OfflineBuildTempDir%\Package\package.tar" -o"%OfflineBuildTempDir%\Package" -aoa
+
+ECHO Copying Windows platform package...
+:: ====================================================
+%robocopy% /E "%OfflineBuildTempDir%\Package\package" "%DependenciesDir%\lib\windows\cordova\%CordovaWindowsVersion%"
+
+ECHO Copying external dependencies...
+:: ====================================================
+IF "%SkipDownloadNodeNpm%" NEQ "1" (
+	ECHO Downloading and copying Node and NPM...
+	powershell -ExecutionPolicy Bypass -Command "(New-Object Net.WebClient).DownloadFile('https://nodejs.org/dist/v4.4.4/win-x86/node.exe', '%DependenciesDir%\node.exe')"
+	powershell -ExecutionPolicy Bypass -Command "(New-Object Net.WebClient).DownloadFile('https://github.com/npm/npm/archive/v%SandboxedNpmVersion%.zip', '%DependenciesDir%\npm-%SandboxedNpmVersion%.zip')"
+) ELSE (
+	Echo Skipping NPM and Node download...
+	IF exist "%NugetPackageDir%" (
+	%robocopy% /E "%NugetPackageDir%" "%DependenciesDir%"
+	) ELSE (
+		%robocopy% "%~dp0" "%DependenciesDir%" node.exe npm-%SandboxedNpmVersion%.zip
+	)
+)
+
+ECHO Creating nodevars.bat...
+:: ====================================================
+(
+	ECHO @echo off
+	ECHO set PATH=%%APPDATA%%\npm;%%~dp0;%%PATH%%
+	ECHO setlocal enabledelayedexpansion
+	ECHO pushd ""%%~dp0""
+	ECHO set print_version=.\node.exe -p -e "process.versions.node + ' (' + process.arch + ')'"
+	ECHO for /F "usebackq delims=" %%%%v in (`%%print_version%%`^) do set version=%%%%v
+	ECHO popd
+	ECHO endlocal
+	ECHO if "%%CD%%\"=="%%~dp0" cd /d "%%HOMEDRIVE%%%%HOMEPATH%%"
+) > "%DependenciesDir%\nodevars.bat"
+
+ECHO Creating BuildOffline.zip...
+:: ====================================================
+IF NOT EXIST "%OutputDirectory%" mkdir "%OutputDirectory%
+powershell -ExecutionPolicy Bypass -File .\ZipDependencies.ps1 -directoryToZip "%DependenciesDir%" -destination "%OutputDirectory%\\" -sevenZip "%SevenZip%"
+
+ECHO Done!
+goto DONE
+
+:INPUTERROR
+ECHO There was an error with your input.
+ECHO.
+ECHO Usage: CreateOfflineArchive.cmd [OutputDirectory] [SkipDownloadNpmNode] [PathTo7Zip]
+ECHO.
+ECHO OutputDirectory (Required) - A path to a folder you'd like the package to be saved to.
+ECHO SkipDownloadNodeNpm (Optional) - Pass 1 and copy node.exe and npm-%SandboxedNpmVersion%.zip to the same directory as the script to prevent them from being downloaded again.
+ECHO PathTo7Zip (Optional) - A path to 7z.exe. If left empty, it will assume the default 64-bit install location.
+ECHO.
+ECHO.
+
+:DONE

--- a/build-offline/ExtractOfflineArchive.cmd
+++ b/build-offline/ExtractOfflineArchive.cmd
@@ -1,0 +1,55 @@
+@ECHO off
+
+ECHO.
+ECHO Tools for Apache Cordova Offline Build Archive Extractor
+ECHO --------------------------------------------------------
+ECHO.
+
+SET SevenZipDirectory=%1
+
+SET CWD=%~dp0
+SET DependenciesSourceDir=%CWD%Dependencies
+SET NpmSourceDir=%DependenciesSourceDir%\npm
+SET NpmModulesSourceDir=%DependenciesSourceDir%\node_modules
+SET NpmCacheSourceDir=%DependenciesSourceDir%\npm-cache
+SET CordovaCacheSourceDir=%DependenciesSourceDir%\lib
+
+SET SandboxedNpmVersion=2.15.1
+SET SandboxDestDir=%AppData%\Microsoft\VisualStudio\MDA\vs-npm\%SandboxedNpmVersion%
+SET NpmModulesDestDir=%AppData%\npm\node_modules
+SET NpmCacheDestDir=%AppData%\npm-cache
+SET CordovaCacheDestDir=%HomePath%\.cordova\lib
+
+if /I "%robocopy%"=="" SET robocopy=robocopy /NJH /NJS
+
+ECHO Unzipping Dependencies...
+:: ====================================================
+mkdir %DependenciesSourceDir%
+mkdir %NpmSourceDir%
+powershell -ExecutionPolicy ByPass -File .\UnzipDependencies.ps1 -filename BuildOffline.zip -outputFolder "Dependencies" -sevenZip """%SevenZipDirectory%"""
+powershell -ExecutionPolicy ByPass -File .\UnzipDependencies.ps1 -filename "Dependencies\npm-%SandboxedNpmVersion%.zip" -outputFolder "Dependencies\npm"
+
+ECHO Sandboxing node and npm...
+:: ====================================================
+mkdir %SandboxDestDir%
+%robocopy% "%DependenciesSourceDir%" "%SandboxDestDir%" node.exe nodevars.bat
+%robocopy% /E "%NpmSourceDir%\npm-%SandboxedNpmVersion%" "%SandboxDestDir%\node_modules\npm"
+%robocopy% "%NpmSourceDir%\npm-%SandboxedNpmVersion%\bin" "%SandboxDestDir%" npm npm.cmd
+call "%SandboxDestDir%\npm.cmd" config SET prefix -g "${APPDATA}/npm"
+
+ECHO Copying node_modules...
+:: ====================================================
+mkdir %NpmModulesDestDir%
+%robocopy% /E "%NpmModulesSourceDir%" "%NpmModulesDestDir%"
+
+ECHO Copying npm-cache...
+:: ====================================================
+mkdir %NpmCacheDestDir%
+%robocopy% /E "%NpmCacheSourceDir%" "%NpmCacheDestDir%"
+
+ECHO Copying Cordova Cache...
+:: ====================================================
+mkdir %CordovaCacheDestDir%
+%robocopy% /E %CordovaCacheSourceDir% %CordovaCacheDestDir%
+
+ECHO Done!

--- a/build-offline/Readme.md
+++ b/build-offline/Readme.md
@@ -1,0 +1,25 @@
+# README
+
+This project contains a set of example scripts that let you take resource from a machine with internet access and deploy them to a target machine in order to create a limited offline Visual Studio + Cordova development environment.
+
+## Usage
+### CreateOfflineArchive.cmd  
+
+This script should be run on a machine with internet access. It assumes you have Nodejs and 7zip installed. The script has the following output:
+- BuildOffline.zip - An archive containing the dependencies needed to establish a limited offline development environment.
+- ExtractOfflineArchive.cmd - A script that "installs" these dependencies (see below).
+- UnzipDependencies.ps1 - A helper script used to extract the archive.
+
+**Usage:** CreateOfflineArchive.cmd [OutputDirectory] [SkipDownloadNpmNode] [PathTo7Zip]
+
+- **OutputDirectory (Required)** - A path to a folder you'd like the package to be saved to.  
+- **SkipDownloadNodeNpm (Optional)** - Pass 1 and copy node.exe and npm-%SandboxedNpmVersion%.zip to the same directory as the script to prevent them from being downloaded again.  
+- **PathTo7Zip (Optional)** - A path to 7z.exe or 7za.exe. If left empty, it will assume the default 64-bit install location.
+
+### ExtractOfflineArchive.cmd
+
+This script should be copied to a temporary directory along with the **BuildOffline.zip** and **UnzipDependencies.ps1**. Running the script will unpack the archive and copy the components into the locations needed to create a limited offline development environment.
+
+**Usage:** ExtractOfflineArchive.cmd [PathTo7Zip]
+
+- **PathTo7Zip (Optional)** - A path to 7z.exe or 7za.exe. If left empty, it will attempt to use the shell, which may fail if part of the archive breaks the Windows max file path limit.

--- a/build-offline/UnzipDependencies.ps1
+++ b/build-offline/UnzipDependencies.ps1
@@ -1,0 +1,14 @@
+param (
+    [string]$filename = $(throw "-filename is required."),
+    [string]$outputFolder = $(throw "-outputFolder is required."), 
+    [string]$sevenZip = ""
+)
+if("" -ne $sevenZip){
+    $cmd = '& ' + $sevenZip + 'x ' + $filename + ' ' + $outputFolder + ' -aoa'
+    Invoke-Expression $cmd
+}else{
+    $shell_app=new-object -com shell.application
+    $zip_file = $shell_app.namespace((Get-Location).Path + "\$filename")
+    $destination = $shell_app.namespace((Get-Location).Path + "\$outputFolder")
+    $destination.Copyhere($zip_file.items());
+}

--- a/build-offline/ZipDependencies.ps1
+++ b/build-offline/ZipDependencies.ps1
@@ -1,0 +1,11 @@
+param (
+    [string]$directoryToZip = $(throw "-directoryToZip is required."),
+    [string]$destination = $(throw "-destination is required."),
+    [string]$sevenZip = $(throw "-sevenZip is required.")
+)
+$destinationFile = $destination + "BuildOffline.zip"
+If (Test-Path $destinationFile){
+    Remove-Item $destinationFile
+}
+$cmd = '& ' + $sevenZip + 'a ' + $destinationFile + ' ' + $directoryToZip
+Invoke-Expression $cmd


### PR DESCRIPTION
This is a set of example scripts that can be used to enable a limited development environment for VS + Cordova while offline. These scripts essentially perform the steps described in an upcoming blog post on the Tools for Apache Cordova developer blog.