### PR TITLE
fixed license formatting in weather-app-ionic readme

### DIFF
--- a/weather-app-ionic2/WeatherAppIonic2/src/index.html
+++ b/weather-app-ionic2/WeatherAppIonic2/src/index.html
@@ -2,7 +2,7 @@
 <html lang="en" dir="ltr">
 <head>
   <meta charset="UTF-8">
-  <title>Ionic App</title>
+  <title>Weather App Ionic 2</title>
   <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no">
   <meta name="format-detection" content="telephone=no">
   <meta name="msapplication-tap-highlight" content="no">

--- a/weather-app-ionic2/readme.md
+++ b/weather-app-ionic2/readme.md
@@ -38,8 +38,8 @@ By downloading and running this project, you agree to the license terms of the t
 The third party software and products are provided to you by third parties. You are responsible for reading and accepting the relevant license terms for all software that will be installed. Microsoft grants you no rights to third party software.
 
 ## License
-
-```The MIT License (MIT)
+```
+The MIT License (MIT)
 
 Copyright (c) Microsoft Corporation
 
@@ -59,7 +59,8 @@ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.```
+SOFTWARE.
+```
 
 ## Help us improve our samples
 Help us improve out samples by sending us a pull-request or opening a [GitHub Issue](https://github.com/Microsoft/cordova-samples/issues/new)


### PR DESCRIPTION
License wasn't rendering as code, so I fixed it.